### PR TITLE
Use given URL_ID for the container url if given

### DIFF
--- a/scripts/test_env_file
+++ b/scripts/test_env_file
@@ -1,3 +1,4 @@
-USER=user
-JPY_USER=user
-JPY_BASE_USER_URL=/user/user
+USER=username
+JPY_USER=username
+JPY_BASE_USER_URL=/user/username
+URL_ID=unique_path

--- a/scripts/test_novnc_directly.sh
+++ b/scripts/test_novnc_directly.sh
@@ -71,9 +71,6 @@ if test $? != 0; then
     exit 1
 fi
 
-# Get id
-container_id=`docker inspect -f "{{ .Id }}" $3`
-
 # Get HostIp and HostPort
 host_ip=`docker inspect --format '{{ (index (index .NetworkSettings.Ports "8888/tcp") 0).HostIp }}' $3`
 host_port=`docker inspect --format '{{ (index (index .NetworkSettings.Ports "8888/tcp") 0).HostPort }}' $3`
@@ -83,10 +80,8 @@ if [[ "`uname`" != 'Linux' ]]; then
     host_ip=`docker-machine ip`
 fi
 
-# Base user URL
-JPY_BASE_USER_URL=`grep JPY_BASE_USER_URL $2 | awk -F'=' '{print $2}'`
-
 # Complete URL for inspection
-URL="http://${host_ip}:${host_port}${JPY_BASE_USER_URL}/containers/${container_id}"
+# Assume the first location gives you the right URL
+URL="http://${host_ip}:${host_port}"`docker exec $3 /bin/bash -c "grep 'location' /etc/nginx/sites-enabled/default | head -1 | grep -oE '[^ {=]+' | tail -1"`
 echo $URL
 open_path=$(which xdg-open || which gnome-open || which open) && exec "$open_path" "$URL"

--- a/wrapper/container-files/startup.sh
+++ b/wrapper/container-files/startup.sh
@@ -25,15 +25,18 @@ mkdir -p /var/run/sshd
 # This is the only effective way I found to obtain the full container id from
 # within the container. We can't have it passed from the outside, or we have a
 # chicken-egg problem, and --cidfile is unsupported by dockerpy
-_tmp=`cat /proc/self/cgroup | grep ":cpu:" | cut -d: -f 3`
-export CONTAINER_ID="`basename $_tmp`"
+_tmp=`cat /proc/self/cgroup | grep ":cpu" | head -1 | cut -d: -f 3`
+
+# If URL_ID is given as an environment variable, use it,
+# Otherwise, use the container id from $_tmp
+export URL_ID="`(test $URL_ID && echo $URL_ID) || basename $_tmp`"
 
 # Create the user
 id -u $USER &>/dev/null || useradd --create-home --shell /bin/bash --user-group $USER
 echo "$USER:$USER" | chpasswd
 
 # Parse the templates and put their result in the appropriate places
-cat /templates/nginx.conf.template | envsubst '$JPY_BASE_USER_URL $CONTAINER_ID' > /etc/nginx/sites-enabled/default
+cat /templates/nginx.conf.template | envsubst '$JPY_BASE_USER_URL $URL_ID' > /etc/nginx/sites-enabled/default
 cat /templates/supervisord.conf.template | envsubst '$USER' > /etc/supervisor/conf.d/supervisord.conf
 
 # Start the services

--- a/wrapper/container-files/templates/nginx.conf.template
+++ b/wrapper/container-files/templates/nginx.conf.template
@@ -4,16 +4,16 @@ server {
         root /usr/share/nginx/html;
         index index.html index.htm;
 
-        location = $JPY_BASE_USER_URL/containers/$CONTAINER_ID {
+        location = $JPY_BASE_USER_URL/containers/$URL_ID {
             try_files /redirect.html =404;
         }
 
-        location = $JPY_BASE_USER_URL/containers/$CONTAINER_ID/loading.gif {
+        location = $JPY_BASE_USER_URL/containers/$URL_ID/loading.gif {
             try_files /loading.gif =404;
         }
 
-        location = $JPY_BASE_USER_URL/containers/$CONTAINER_ID/websockify {
-            rewrite ^$JPY_BASE_USER_URL/containers/$CONTAINER_ID/(.*)$ /$1 break;
+        location = $JPY_BASE_USER_URL/containers/$URL_ID/websockify {
+            rewrite ^$JPY_BASE_USER_URL/containers/$URL_ID/(.*)$ /$1 break;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
@@ -21,8 +21,8 @@ server {
             proxy_read_timeout 86400;
         }
 
-        location $JPY_BASE_USER_URL/containers/$CONTAINER_ID/ {
-            rewrite ^$JPY_BASE_USER_URL/containers/$CONTAINER_ID/(.*)$ /$1 break;
+        location $JPY_BASE_USER_URL/containers/$URL_ID/ {
+            rewrite ^$JPY_BASE_USER_URL/containers/$URL_ID/(.*)$ /$1 break;
             proxy_set_header X-Real-IP  $remote_addr;
             proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header Host $host;


### PR DESCRIPTION
Fix #4 
- If environment variable URL_ID is given, use it for the url.  Otherwise, use the container id.
- Updated the script `test_novnc_directly.sh`.

The script `test_novnc_directly.sh` should still work with old images.
