### PR TITLE
Fix script for testing image novnc access

### DIFF
--- a/scripts/test_novnc_directly.sh
+++ b/scripts/test_novnc_directly.sh
@@ -49,7 +49,7 @@ if [ -z "$3" ]; then
 fi
 
 
-if test "`docker ps -a -f name=$3 | wc -l`" -gt 1; then
+if docker inspect $3 > /dev/null 2>&1; then
     read -p "$3 already exists.  Do you want to stop and/or remove it? [Y/n] " -n 1 -r
     echo
     if [[ $REPLY =~ ^[Yy]$ ]]; then


### PR DESCRIPTION
`docker ps -a -f --name=something` matches container with name `*something` or `something*` while we meant to match the container name exactly.
`docker inspect` does exactly what we need.
