### PR TITLE
Provide full access to filesystem

### DIFF
--- a/images/filetransfer/container-files/wsgi.py
+++ b/images/filetransfer/container-files/wsgi.py
@@ -25,11 +25,10 @@ class ReverseProxied(object):
         return self.app(environ, start_response)
 
 
-homedir = os.environ["HOME"]
 app.config.update(
-    directory_base=homedir,
-    directory_start=homedir,
-    directory_remove=homedir,
-    directory_upload=homedir,
+    directory_base="/",
+    directory_start="/",
+    directory_remove="/",
+    directory_upload="/",
 )
 app = ReverseProxied(app)


### PR DESCRIPTION
The user already has full access in other images.
It makes little sense to restrict the access for the import/export.
