### PR TITLE
Added type label to the base images

### DIFF
--- a/wrappers/vncapp/Dockerfile.template
+++ b/wrappers/vncapp/Dockerfile.template
@@ -1,5 +1,7 @@
 FROM $IMAGE_NAME
 
+LABEL eu.simphony-project.docker.type="vncapp"
+
 # startup.sh noVNC front-end, websocket,
 # nginx template and supervisor template...
 COPY container-files/ /

--- a/wrappers/webapp/Dockerfile.template
+++ b/wrappers/webapp/Dockerfile.template
@@ -1,5 +1,7 @@
 FROM $IMAGE_NAME
 
+LABEL eu.simphony-project.docker.type="webapp"
+
 COPY container-files/ /
 
 WORKDIR /root


### PR DESCRIPTION
Introduce the "type" label to allow differentiation between
the two types of images, so that proper configuration parameters
can be passed.
